### PR TITLE
add Athena logging option

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -23,3 +23,25 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f8db068265495a48476a5ea68aa7148ceb046cbfaad308ef8e12d8fd6f463126",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
+    "h1:vUW21lLLsKlxtBf0QF7LKJreKxs0CM7YXGzqW1N/ODY=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}

--- a/athena.tf
+++ b/athena.tf
@@ -1,0 +1,33 @@
+
+resource "aws_athena_database" "this" {
+  count = var.create_athena_query ? 1 : 0
+
+  name    = "elb_logs"
+  bucket  = aws_s3_bucket.this.bucket
+  comment = "Database for ELB logs in bucket ${aws_s3_bucket.this.bucket}"
+
+  encryption_configuration {
+    encryption_option = "SSE_S3"
+  }
+}
+
+resource "null_resource" "create_table" {
+  count = var.create_athena_query ? 1 : 0
+
+  triggers = {
+    athena_database = aws_athena_database.this[0].id
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command = templatefile("${path.module}/templates/create_table.sh.tpl", {
+      results_config    = "OutputLocation=s3://${aws_s3_bucket.this.bucket}/elblogging-athena-results"
+      execution_context = "Database=${aws_athena_database.this[0].id}"
+      query_string = templatefile("${path.module}/templates/create_table.sql.tpl", {
+        bucket     = aws_s3_bucket.this.bucket
+        account_id = local.account_id
+        region     = local.region
+      })
+    })
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,3 +12,15 @@ output "s3_bucket_name" {
   description = "The name of the bucket"
   value       = aws_s3_bucket.this.bucket
 }
+
+##########################################
+# AWS Athena
+##########################################
+
+output "delete_athena_table_comand" {
+  description = "The command to delete the athena table. This is given as an output as the destroy-time provisioner does not take arguments from external resources"
+  value = var.create_athena_query ? templatefile("${path.module}/templates/delete_table.sh.tpl", {
+    results_config    = "OutputLocation=s3://${aws_s3_bucket.this.bucket}/elblogging-athena-results"
+    execution_context = "Database=${aws_athena_database.this[0].id}"
+  }) : "Table not set to create"
+}

--- a/templates/create_table.sh.tpl
+++ b/templates/create_table.sh.tpl
@@ -1,0 +1,4 @@
+aws athena start-query-execution \
+	--query-string "${query_string}" \
+	--result-configuration "${results_config}" \
+	--query-execution-context "${execution_context}"

--- a/templates/create_table.sql.tpl
+++ b/templates/create_table.sql.tpl
@@ -1,0 +1,42 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS alb_logs (
+            type string,
+            time string,
+            elb string,
+            client_ip string,
+            client_port int,
+            target_ip string,
+            target_port int,
+            request_processing_time double,
+            target_processing_time double,
+            response_processing_time double,
+            elb_status_code int,
+            target_status_code string,
+            received_bytes bigint,
+            sent_bytes bigint,
+            request_verb string,
+            request_url string,
+            request_proto string,
+            user_agent string,
+            ssl_cipher string,
+            ssl_protocol string,
+            target_group_arn string,
+            trace_id string,
+            domain_name string,
+            chosen_cert_arn string,
+            matched_rule_priority string,
+            request_creation_time string,
+            actions_executed string,
+            redirect_url string,
+            lambda_error_reason string,
+            target_port_list string,
+            target_status_code_list string,
+            classification string,
+            classification_reason string
+  )
+  ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
+  WITH SERDEPROPERTIES (
+  'serialization.format' = '1',
+  'input.regex' =
+          '([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) ([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) \"([^ ]*) (.*) (- |[^ ]*)\" \"([^\"]*)\" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^\"]*)\" ([-.0-9]*) ([^ ]*) \"([^\"]*)\" \"([^\"]*)\" \"([^ ]*)\" \"([^\s]+?)\" \"([^\s]+)\" \"([^ ]*)\" \"([^ ]*)\"')
+
+  LOCATION 's3://${bucket}/AWSLogs/${account_id}/elasticloadbalancing/${region}/';

--- a/templates/delete_table.sh.tpl
+++ b/templates/delete_table.sh.tpl
@@ -1,0 +1,4 @@
+aws athena start-query-execution \
+	--query-string 'DROP TABLE IF EXISTS alb_logs;' \
+	--result-configuration "${results_config}" \
+	--query-execution-context "${execution_context}"

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "bucket_suffix" {
   type        = string
 }
 
+variable "create_athena_query" {
+  default     = true
+  description = "Create an Athena table for querying ALB logs. Uses the aws cli"
+  type        = bool
+}
+
 variable "lifecycle_rules" {
   default     = []
   description = "lifecycle rules to apply to the bucket"

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.8"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3"
+    }
   }
 }


### PR DESCRIPTION
Here are my notes from tackling this problem, they may be useful to those in the future that wish to improve upon my solution:

---

In adding an AWS Athena ELB logging table to our ELB logging module I faced several design choices and one primary problem - the problem was (and still is) that [one must run an Athena query to create an ELB logging table](https://docs.aws.amazon.com/athena/latest/ug/application-load-balancer-logs.html) (with a CREATE TABLE statement) but there is no terraform or CloudFormation resource for that. That leaves two options: do this manually or try and hack in that functionality by using the aws CLI or something. Arguably the former is the more prudent choice and this is a one time activity that takes virtually no time. Given any pressure to deliver value one should choose the former. Fortunately I have no client pressures this morning and am several cups of coffee into solving what has become a personal issue. We are also very fortunate that the AWS CLI gives us the ability [to start queries](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/athena/start-query-execution.html) and to[ get a query execution status](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/athena/get-query-execution.html). I found a wonderful example [on SO of almost exactly what I want to do but with a simpler query](https://stackoverflow.com/a/56300872/5568528).  Now to script this so that it will run the query and then wait until the query status is completed (or no longer in progress or whatever) and make this happen in terraform. 
There are many different ways to run bash in terraform. There is the [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) with it's triggers, the [external data source](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/data_source) like we use in [our errorcheck module](https://github.com/rhythmictech/terraform-terraform-errorcheck/blob/master/main.tf), and specially for the AWS CLI there is [a module to run just that](https://github.com/digitickets/terraform-aws-cli) under active development. The ability to both create and destroy the table is ideal so the null_resource was selected first. It turns out this isn't possible because running the destroy command requires inputs that aren't available during a destroy (see error below). 
```
│ Error: Invalid reference from destroy provisioner
│ 
│   on .terraform/modules/elblogging_bucket/athena.tf line 37, in resource "null_resource" "create_table":
│   37:     command = templatefile("${path.module}/templates/delete_table.sh.tpl", {
│   38:       results_config    = "OutputLocation=s3://${aws_s3_bucket.this.bucket}/elblogging-athena-results"
│   39:       execution_context = "Database=${aws_athena_database.this[0].id}"
│   40:     })
│ 
│ Destroy-time provisioners and their connection configurations may only reference attributes of the related resource, via
│ 'self', 'count.index', or 'each.key'.
│ 
│ References to other resources during the destroy phase can cause dependency cycles and interact poorly with
│ create_before_destroy.
```
We could spit this command out to the local path and give users the option to commit it to version control in the repository calling the module. I'd like to steer clear of local_file though because they always end up creating noisy terraform plans. 
Ultimately my grand plans started to seem unobtainable during a relaxed morning. I'd spent nearly two hours and become vary familiar with the problem posed by Athena with terraform, alternative ways of running the desired commands, ways of running those commands inside terraform, and discovered a limitation of the destroy time provisioner. Reducing the scope of this MVP to just creating the table would allow me to fit it into a single local-exec command, which means I don't have to deal with the messy plans that come with a local_file and can get away with just adding one more resource.